### PR TITLE
Various Fixes

### DIFF
--- a/mp3serial_JQ8400TF.cpp
+++ b/mp3serial_JQ8400TF.cpp
@@ -153,7 +153,7 @@ void mp3Serial::injectSong(uint16_t index)
 	};
 
 // play song INDEX from folder FOLDER
-void playFromFolder(uint8_t folder, uint8t index)
+void playFromFolder(uint8_t folder, uint8_t index)
 	{
 	write_3bytes(CMD_PLAY_DIR_INDEX, (uint16_t)((folder<<8)|index)); 
 	};

--- a/mp3serial_JQ8400TF.cpp
+++ b/mp3serial_JQ8400TF.cpp
@@ -46,12 +46,12 @@ void mp3Serial::begin(void)
 		case 0:
 			Serial.begin(9600);
 			break;
-		#ifdef AVR_LEONARDO || AVR_MEGA || AVR_MEGA2560
+		#if defined(AVR_LEONARDO) || defined(AVR_MEGA) || defined(AVR_MEGA2560)
 		case 1:
 			Serial1.begin(9600);
 			break;
 		#endif
-		#ifdef AVR_MEGA || AVR_MEGA2560
+		#if defined(AVR_MEGA) || defined(AVR_MEGA2560)
 		case 2:
 			Serial2.begin(9600);
 			break;
@@ -171,12 +171,12 @@ void mp3Serial::write_nBytes(uint8_t n)
 		case 0:
 			Serial.write(mp3Buffer[i]);
 			break;
-		#ifdef AVR_LEONARDO || AVR_MEGA || AVR_MEGA2560
+		#if defined(AVR_LEONARDO) || defined(AVR_MEGA) || defined(AVR_MEGA2560)
 		case 1:
 			Serial1.write(mp3Buffer[i]);
 			break;
 		#endif
-		#ifdef AVR_MEGA || AVR_MEGA2560
+		#if defined(AVR_MEGA) || defined(AVR_MEGA2560)
 		case 2:
 			Serial2.write(mp3Buffer[i]);
 			break;

--- a/mp3serial_JQ8400TF.cpp
+++ b/mp3serial_JQ8400TF.cpp
@@ -153,7 +153,7 @@ void mp3Serial::injectSong(uint16_t index)
 	};
 
 // play song INDEX from folder FOLDER
-void playFromFolder(uint8_t folder, uint8_t index)
+void mp3Serial::playFromFolder(uint8_t folder, uint8_t index)
 	{
 	write_3bytes(CMD_PLAY_DIR_INDEX, (uint16_t)((folder<<8)|index)); 
 	};

--- a/mp3serial_JQ8400TF.h
+++ b/mp3serial_JQ8400TF.h
@@ -91,7 +91,7 @@ class mp3Serial
 		void setVolume(uint8_t volume);
 		void playWithVolume(uint8_t volume, uint8_t index);
 		void injectSong(uint16_t index);
-		void playFromFolder(uint8_t folder, uint8t index);
+		void playFromFolder(uint8_t folder, uint8_t index);
 				
 	private:
 		void write_nBytes(uint8_t n);


### PR DESCRIPTION
Some codes do not work correctly or might cause problems when not running in Arduino IDE. This should fix them without impacting the functionality

1. IFDEF should not be used with OR (warning: extra tokens at end of #ifdef directive)
2. uint8t isn't a valid type (error: 'uint8t' has not been declared)
3. write_3bytes is missing the namespace definition (error: 'write_3bytes' was not declared in this scope)